### PR TITLE
SE-0079 Update

### DIFF
--- a/README.markdown
+++ b/README.markdown
@@ -692,16 +692,16 @@ Code should not create reference cycles. Analyze your object graph and prevent s
 
 ### Extending object lifetime
 
-Extend object lifetime using the `[weak self]` and `guard let strongSelf = self else { return }` idiom. `[weak self]` is preferred to `[unowned self]` where it is not immediately obvious that `self` outlives the closure. Explicitly extending lifetime is preferred to optional unwrapping.
+Extend object lifetime using the `[weak self]` and `guard let self = self else { return }` idiom. `[weak self]` is preferred to `[unowned self]` where it is not immediately obvious that `self` outlives the closure. Explicitly extending lifetime is preferred to optional unwrapping.
 
 **Preferred**
 ```swift
 resource.request().onComplete { [weak self] response in
-  guard let strongSelf = self else {
+  guard let self = self else {
     return
   }
-  let model = strongSelf.updateModel(response)
-  strongSelf.updateUI(model)
+  let model = self.updateModel(response)
+  self.updateUI(model)
 }
 ```
 
@@ -720,6 +720,30 @@ resource.request().onComplete { [unowned self] response in
 resource.request().onComplete { [weak self] response in
   let model = self?.updateModel(response)
   self?.updateUI(model)
+}
+```
+
+**Not Preferred**
+```swift
+// This has been confirmed as a compiler hack and should be avoided
+resource.request().onComplete { [weak self] response in
+  guard let `self` = self else {
+    return
+  }
+  let model = strongSelf.updateModel(response)
+  strongSelf.updateUI(model)
+}
+```
+
+**Not Preferred**
+```swift
+// Lacks consistency and makes the codebase harder to reason about
+resource.request().onComplete { [weak self] response in
+  guard let strongSelf = self else {
+    return
+  }
+  let model = strongSelf.updateModel(response)
+  strongSelf.updateUI(model)
 }
 ```
 


### PR DESCRIPTION
Currently, our style guide states to attain a strong reference to `self` when capturing `self` weakly inside a block, we use the `strongSelf` idiom. SE-0079 discussed in detail the different approaches you could take to resolve this to a strong reference. It also suggested a new approach, which has been accepted and now implemented as part of Swift 4.2. 

As such, I propose we update our style guide to support this new Swift feature. Essentially now we can treat `self` as any other optional and unwrap it while keeping the same name. This gives consistency throughout the codebase.

More details around this can be found here: https://github.com/apple/swift-evolution/blob/master/proposals/0079-upgrade-self-from-weak-to-strong.md

This PR is designed very much as a discussion point. So I would love to know what everyone thinks.

I've just randomly picked some reviewers. If I didn't pick you and you want to get involved, feel free to do so :smile: