### PR TITLE
Add and refine guidelines

### DIFF
--- a/CREDITS.markdown
+++ b/CREDITS.markdown
@@ -1,34 +1,5 @@
 ## Credits
 
-[Ray Fix](https://github.com/rayfix) currently maintains this style guide.
-It is a collaborative effort from the most stylish raywenderlich.com team members and its community: 
+[Mindera iOS Team](https://github.com/orgs/Mindera/teams/ios) currently maintains this style guide.
 
-* [Jawwad Ahmad](https://github.com/jawwad)
-* [Soheil Moayedi Azarpour](https://github.com/moayes)
-* [Scott Berrevoets](https://github.com/Scott90)
-* [Jessy Catterwaul](https://github.com/JessyCatterwaul)
-* [Eric Cerney](https://github.com/ecerney)
-* [Sam Davies](https://github.com/sammyd)
-* [Evan Dekhayser](https://github.com/edekhayser)
-* [Jean-Pierre Distler](https://github.com/pdistler)
-* [Colin Eberhardt](https://github.com/ColinEberhardt)
-* [Vadim Eisenberg](https://github.com/vadimeisenbergibm)
-* [Ray Fix](https://github.com/rayfix)
-* [Joshua Greene](https://github.com/JRG-Developer)
-* [Robert Gummesson](https://github.com/RobertGummesson)
-* [Greg Heo](https://github.com/gregheo)
-* [Matthijs Hollemans](https://github.com/hollance)
-* [Erik Kerber](https://github.com/eskerber)
-* [Christopher LaPollo](https://github.com/elephantronic)
-* [Ben Morrow](https://github.com/benmorrow)
-* [Andy Pereira](https://github.com/macandyp)
-* [Ryan Nystrom](https://github.com/rnystrom)
-* [Andy Obusek](https://github.com/obuseme)
-* [Cesare Rocchi](https://github.com/funkyboy)
-* [Ellen Shapiro](https://github.com/designatednerd)
-* [Marin Todorov](https://github.com/icanzilb)
-* [Chris Wagner](https://github.com/cwagdev)
-* [Ray Wenderlich](https://github.com/rwenderlich)
-* [Jack Wu](https://github.com/jackwu95)
-
-Hat tip to [Nicholas Waynik](https://github.com/ndubbs) and the [Objective-C Style Guide](https://github.com/raywenderlich/objective-c-style-guide) team!
+Hat tip to the [Ray Wenderlich's Swift Style Guide](https://github.com/raywenderlich/swift-style-guide) team!

--- a/LICENSE.txt
+++ b/LICENSE.txt
@@ -1,6 +1,9 @@
 
 This style guide is available under the MIT license:
 
+Copyright for portions of this style guide are held by Razeware LLC, 2016-2017. 
+All other copyright for this style guide are held by Mindera, 2017-present.
+
 Copyright (c) 2016-2017 Razeware LLC
 
 Permission is hereby granted, free of charge, to any person obtaining a copy

--- a/README.markdown
+++ b/README.markdown
@@ -3,47 +3,52 @@
 
 ## Table of Contents
 
-* [Correctness](#correctness)
-* [Naming](#naming)
-  * [Prose](#prose)
-  * [Delegates](#delegates)
-  * [Use Type Inferred Context](#use-type-inferred-context)
-  * [Generics](#generics)
-  * [Class Prefixes](#class-prefixes)
-  * [Language](#language)
-* [Code Organization](#code-organization)
-  * [Protocol Conformance](#protocol-conformance)
-  * [Unused Code](#unused-code)
-  * [Minimal Imports](#minimal-imports)
-* [Spacing](#spacing)
-* [Comments](#comments)
-* [Classes and Structures](#classes-and-structures)
-  * [Use of Self](#use-of-self)
-  * [Protocol Conformance](#protocol-conformance)
-  * [Computed Properties](#computed-properties)
-  * [Final](#final)
-* [Function Declarations](#function-declarations)
-* [Closure Expressions](#closure-expressions)
-* [Types](#types)
-  * [Constants](#constants)
-  * [Static Methods and Variable Type Properties](#static-methods-and-variable-type-properties)
-  * [Optionals](#optionals)
-  * [Lazy Initialization](#lazy-initialization)
-  * [Type Inference](#type-inference)
-  * [Syntactic Sugar](#syntactic-sugar)
-* [Functions vs Methods](#functions-vs-methods)
-* [Memory Management](#memory-management)
-  * [Extending Lifetime](#extending-lifetime)
-* [Access Control](#access-control)
-* [Control Flow](#control-flow)
-* [Golden Path](#golden-path)
-  * [Failing Guards](#failing-guards)
-* [Semicolons](#semicolons)
-* [Parentheses](#parentheses)
-* [Organization and Bundle Identifier](#organization-and-bundle-identifier)
-* [Copyright Statement](#copyright-statement)
-* [Smiley Face](#smiley-face)
-* [References](#references)
+- [The Mindera Swift Style Guide](#the-mindera-swift-style-guide)
+  - [Table of Contents](#table-of-contents)
+  - [Correctness](#correctness)
+  - [Naming](#naming)
+    - [Prose](#prose)
+    - [Class Prefixes](#class-prefixes)
+    - [Delegates](#delegates)
+    - [Use Type Inferred Context](#use-type-inferred-context)
+    - [Generics](#generics)
+    - [Language](#language)
+  - [Code Organization](#code-organization)
+    - [Protocol Conformance](#protocol-conformance)
+    - [Unused Code](#unused-code)
+    - [Minimal Imports](#minimal-imports)
+  - [Spacing](#spacing)
+  - [Comments](#comments)
+  - [Classes and Structures](#classes-and-structures)
+    - [Which one to use?](#which-one-to-use)
+    - [Example definition](#example-definition)
+    - [Use of Self](#use-of-self)
+    - [Computed Properties](#computed-properties)
+    - [Final](#final)
+  - [Function Declarations](#function-declarations)
+  - [Function Calls](#function-calls)
+  - [Closure Expressions](#closure-expressions)
+  - [Types](#types)
+    - [Constants](#constants)
+    - [Static Methods and Variable Type Properties](#static-methods-and-variable-type-properties)
+    - [Optionals](#optionals)
+    - [Lazy Initialization](#lazy-initialization)
+    - [Type Inference](#type-inference)
+      - [Type Annotation for Empty Arrays and Dictionaries](#type-annotation-for-empty-arrays-and-dictionaries)
+    - [Syntactic Sugar](#syntactic-sugar)
+  - [Functions vs Methods](#functions-vs-methods)
+  - [Memory Management](#memory-management)
+    - [Extending object lifetime](#extending-object-lifetime)
+  - [Access Control](#access-control)
+  - [Control Flow](#control-flow)
+    - [Ternary Operator](#ternary-operator)
+  - [Golden Path](#golden-path)
+    - [Failing Guards](#failing-guards)
+  - [Semicolons](#semicolons)
+  - [Parentheses](#parentheses)
+  - [Multi-line String Literals](#multi-line-string-literals)
+  - [Organization and Bundle Identifier](#organization-and-bundle-identifier)
+  - [References](#references)
 
 
 ## Correctness
@@ -77,6 +82,7 @@ Descriptive and consistent naming makes software easier to read and understand. 
 - giving the same base name to methods that share the same meaning
 - avoiding overloads on return type
 - choosing good parameter names that serve as documentation
+- preferring to name the first parameter instead of including its name in the method name, except as mentioned under Delegates
 - labeling closure and tuple parameters
 - taking advantage of default parameters
 
@@ -84,13 +90,13 @@ Descriptive and consistent naming makes software easier to read and understand. 
 
 When referring to methods in prose, being unambiguous is critical. To refer to a method name, use the simplest form possible.
 
-1. Write the method name with no parameters.  **Example:** Next, you need to call the method `addTarget`.
-2. Write the method name with argument labels.  **Example:** Next, you need to call the method `addTarget(_:action:)`.
-3. Write the full method name with argument labels and types. **Example:** Next, you need to call the method `addTarget(_: Any?, action: Selector?)`.
+1. Write the method name with no parameters.  **Example:** Next, you need to call `addTarget`.
+2. Write the method name with argument labels.  **Example:** Next, you need to call `addTarget(_:action:)`.
+3. Write the full method name with argument labels and types. **Example:** Next, you need to call `addTarget(_: Any?, action: Selector?)`.
 
 For the above example using `UIGestureRecognizer`, 1 is unambiguous and preferred.
 
-**Pro Tip:** You can use Xcode's jump bar to lookup methods with argument labels.
+**Pro Tip:** You can use Xcode's jump bar to lookup methods with argument labels. If you’re particularly good at mashing lots of keys simultaneously, put the cursor in the method name and press **Shift-Control-Option-Command-C** (all 4 modifier keys) and Xcode will kindly put the signature on your clipboard.
 
 ![Methods in Xcode jump bar](screens/xcode-jump-bar.png)
 
@@ -109,13 +115,13 @@ let myClass = MyModule.UsefulClass()
 
 When creating custom delegate methods, an unnamed first parameter should be the delegate source. (UIKit contains numerous examples of this.)
 
-**Preferred:**
+**Preferred**:
 ```swift
 func namePickerView(_ namePickerView: NamePickerView, didSelectName name: String)
 func namePickerViewShouldReload(_ namePickerView: NamePickerView) -> Bool
 ```
 
-**Not Preferred:**
+**Not Preferred**:
 ```swift
 func didSelectName(namePicker: NamePickerViewController, name: String)
 func namePickerShouldReload() -> Bool
@@ -125,7 +131,7 @@ func namePickerShouldReload() -> Bool
 
 Use compiler inferred context to write shorter, clear code.  (Also see [Type Inference](#type-inference).)
 
-**Preferred:**
+**Preferred**:
 ```swift
 let selector = #selector(viewDidLoad)
 view.backgroundColor = .red
@@ -133,7 +139,7 @@ let toView = context.view(forKey: .to)
 let view = UIView(frame: .zero)
 ```
 
-**Not Preferred:**
+**Not Preferred**:
 ```swift
 let selector = #selector(ViewController.viewDidLoad)
 view.backgroundColor = UIColor.red
@@ -145,14 +151,14 @@ let view = UIView(frame: CGRect.zero)
 
 Generic type parameters should be descriptive, upper camel case names. When a type name doesn't have a meaningful relationship or role, use a traditional single uppercase letter such as `T`, `U`, or `V`.
 
-**Preferred:**
+**Preferred**:
 ```swift
 struct Stack<Element> { ... }
 func write<Target: OutputStream>(to target: inout Target)
 func swap<T>(_ a: inout T, _ b: inout T)
 ```
 
-**Not Preferred:**
+**Not Preferred**:
 ```swift
 struct Stack<T> { ... }
 func write<target: OutputStream>(to target: inout target)
@@ -163,12 +169,12 @@ func swap<Thing>(_ a: inout Thing, _ b: inout Thing)
 
 Use US English spelling to match Apple's API.
 
-**Preferred:**
+**Preferred**:
 ```swift
 let color = "red"
 ```
 
-**Not Preferred:**
+**Not Preferred**:
 ```swift
 let colour = "red"
 ```
@@ -181,7 +187,7 @@ Use extensions to organize your code into logical blocks of functionality. Each 
 
 In particular, when adding protocol conformance to a model, prefer adding a separate extension for the protocol methods. This keeps the related methods grouped together with the protocol and can simplify instructions to add a protocol to a class with its associated methods.
 
-**Preferred:**
+**Preferred**:
 ```swift
 class MyViewController: UIViewController {
   // class stuff here
@@ -198,7 +204,7 @@ extension MyViewController: UIScrollViewDelegate {
 }
 ```
 
-**Not Preferred:**
+**Not Preferred**:
 ```swift
 class MyViewController: UIViewController, UITableViewDataSource, UIScrollViewDelegate {
   // all methods
@@ -215,14 +221,14 @@ Unused (dead) code, including Xcode template code and placeholder comments shoul
 
 Methods that simply call the superclass should also be removed. This includes any empty/unused UIApplicationDelegate methods.
 
-**Preferred:**
+**Preferred**:
 ```swift
 override func tableView(_ tableView: UITableView, numberOfRowsInSection section: Int) -> Int {
   return Database.contacts.count
 }
 ```
 
-**Not Preferred:**
+**Not Preferred**:
 ```swift
 override func didReceiveMemoryWarning() {
   super.didReceiveMemoryWarning()
@@ -242,16 +248,43 @@ override func tableView(_ tableView: UITableView, numberOfRowsInSection section:
 ```
 ### Minimal Imports
 
-Keep imports minimal. For example, don't import `UIKit` when importing `Foundation` will suffice.
+Import only the modules a source file requires. For example, don't import `UIKit` when importing `Foundation` will suffice. Likewise, don't import `Foundation` if you must import `UIKit`.
+
+**Preferred**:
+```
+import UIKit
+var view: UIView
+var deviceModels: [String]
+```
+
+**Preferred**:
+```
+import Foundation
+var deviceModels: [String]
+```
+
+**Not Preferred**:
+```
+import UIKit
+import Foundation
+var view: UIView
+var deviceModels: [String]
+```
+
+**Not Preferred**:
+```
+import UIKit
+var deviceModels: [String]
+```
 
 ## Spacing
 
 * Indent using 4 spaces rather than tabs to conserve space and help prevent line wrapping. Check xcode settings at the end.
 
 * Method braces and other braces (`if`/`else`/`switch`/`while` etc.) always open on the same line as the statement but close on a new line.
-* Tip: You can re-indent by selecting some code (or ⌘A to select all) and then Control-I (or Editor\Structure\Re-Indent in the menu). Some of the Xcode template code will have 4-space tabs hard coded, so this is a good way to fix that.
+* Tip: You can re-indent by selecting some code (or **Command-A** to select all) and then **Control-I** (or **Editor ▸ Structure ▸ Re-Indent** in the menu). Some of the Xcode template code will have 4-space tabs hard coded, so this is a good way to fix that.
 
-**Preferred:**
+**Preferred**:
 ```swift
 if user.isHappy {
   // Do something
@@ -260,7 +293,7 @@ if user.isHappy {
 }
 ```
 
-**Not Preferred:**
+**Not Preferred**:
 ```swift
 if user.isHappy
 {
@@ -273,26 +306,28 @@ else {
 
 * There should be exactly one blank line between methods to aid in visual clarity and organization. Whitespace within methods should separate functionality, but having too many sections in a method often means you should refactor into several methods.
 
-* Colons always have no space on the left and one space on the right. Exceptions are the ternary operator `? :`, dictionaries (empty 👉 `[:]` | type declaration 👉 `[String : CGFloat]` | populate 👉 `["A" : 1.2]`), `#selector` syntax for unnamed parameters `(_:)` and dictionary 
-* Colons should have one space on the left and one on the right. Exceptions are empty dictionary `[:]` and `#selector` syntax for unnamed parameters `(_:)`.
+* There should always be a blank lines after an opening brace but none before a closing brace.
 
-**Preferred:**
+* Colons always have no space on the left and one space on the right. Exceptions are the ternary operator `? :`, empty dictionary `[:]` and `#selector` syntax `addTarget(_:action:)`.
+
+**Preferred**:
 ```swift
 class TestDatabase: Database {
-  var data: [String : CGFloat] = ["A" : 1.2, "B" : 3.2]
+
+  var data: [String: CGFloat] = ["A": 1.2, "B": 3.2]
 }
 ```
 
-**Not Preferred:**
+**Not Preferred**:
 ```swift
 class TestDatabase : Database {
-  var data :[String:CGFloat] = ["A": 1.2, "B":3.2, "C" :2.2]
+  var data :[String:CGFloat] = ["A" : 1.2, "B":3.2, "C" :2.2]
 }
 ```
 
-* Long lines should be wrapped at around 120 characters. A hard limit is intentionally not specified.
+* Long lines should be wrapped at 120 characters.
 
-* Avoid trailing whitespaces at the ends of lines.
+* Remove any trailing whitespaces at the ends of lines.
 
 * Add a single newline character at the end of each file.
 
@@ -302,8 +337,9 @@ class TestDatabase : Database {
 
 When they are needed, use comments to explain **why** a particular piece of code does something. Comments must be kept up-to-date or deleted.
 
-Avoid block comments inline with code, as the code should be as self-documenting as possible. *Exception: This does not apply to those comments used to generate documentation.*
+Avoid block comments inline with code, as the code should be as self-documenting as possible. _Exception: This does not apply to those comments used to generate documentation._
 
+Avoid the use of C-style comments (`/* ... */`). Prefer the use of double- or triple-slash.
 
 ## Classes and Structures
 
@@ -377,14 +413,14 @@ Use self only when required by the compiler (in `@escaping` closures, or in init
 
 For conciseness, if a computed property is read-only, omit the get clause. The get clause is required only when a set clause is provided.
 
-**Preferred:**
+**Preferred**:
 ```swift
 var diameter: Double {
   return radius * 2
 }
 ```
 
-**Not Preferred:**
+**Not Preferred**:
 ```swift
 var diameter: Double {
   get {
@@ -423,24 +459,68 @@ func reticulateSplines(spline: [Double]) -> Bool {
 }
 ```
 
-For functions with long signatures, add line breaks at appropriate points and add an extra indent on subsequent lines:
+For functions with long signatures, put each parameter on a new line and add an extra indent on subsequent lines:
 
 ```swift
-func reticulateSplines(spline: [Double],
-                       adjustmentFactor: Double,
-                       translateConstant: Int, 
-                       comment: String) -> Bool {
+func reticulateSplines(
+  spline: [Double],
+  adjustmentFactor: Double,
+  translateConstant: Int, comment: String
+) -> Bool {
+
   // reticulate code goes here
 }
 ```
 
 **Note:** We can use Xcode automatic alignment by pressing return before each parameter.
+Don't use `(Void)` to represent the lack of an input; simply use `()`. Use `Void` instead of `()` for closure and function outputs.
+
+**Preferred**:
+
+```swift
+func updateConstraints() -> Void {
+
+  // magic happens here
+}
+
+typealias CompletionHandler = (result) -> Void
+```
+
+**Not Preferred**:
+
+```swift
+func updateConstraints() -> () {
+
+  // magic happens here
+}
+
+typealias CompletionHandler = (result) -> ()
+```
+
+## Function Calls
+
+Mirror the style of function declarations at call sites. Calls that fit on a single line should be written as such:
+
+```swift
+let success = reticulateSplines(splines)
+```
+
+If the call site must be wrapped, put each parameter on a new line, indented one additional level with the closing brace on a line of its own:
+
+```swift
+let success = reticulateSplines(
+  spline: splines,
+  adjustmentFactor: 1.3,
+  translateConstant: 2,
+  comment: "normalize the display"
+)
+```
 
 ## Closure Expressions
 
 Use trailing closure syntax only if there's a single closure expression parameter at the end of the argument list. Give the closure parameters descriptive names.
 
-**Preferred:**
+**Preferred**:
 ```swift
 UIView.animate(withDuration: 1.0) {
   self.myView.alpha = 0
@@ -453,7 +533,7 @@ UIView.animate(withDuration: 1.0, animations: {
 })
 ```
 
-**Not Preferred:**
+**Not Preferred**:
 ```swift
 UIView.animate(withDuration: 1.0, animations: {
   self.myView.alpha = 0
@@ -489,31 +569,37 @@ let value = numbers
 
 ## Types
 
-Always use Swift's native types when available. Swift offers bridging to Objective-C so you can still use the full set of methods as needed.
+Always use Swift's native types and expressions when available. Swift offers bridging to Objective-C so you can still use the full set of methods as needed.
 
-**Preferred:**
+**Preferred**:
+```swift
+let width = 120.0                                    // Double
+let widthString = "\(width)"                         // String
+```
+
+**Less Preferred**:
 ```swift
 let width = 120.0                                    // Double
 let widthString = (width as NSNumber).stringValue    // String
 ```
 
-**Not Preferred:**
+**Not Preferred**:
 ```swift
 let width: NSNumber = 120.0                          // NSNumber
 let widthString: NSString = width.stringValue        // NSString
 ```
 
-In Sprite Kit code, use `CGFloat` if it makes the code more succinct by avoiding too many conversions.
+In drawing code, use `CGFloat` if it makes the code more succinct by avoiding too many conversions.
 
 ### Constants
 
-Constants are defined using the `let` keyword, and variables with the `var` keyword. Always use `let` instead of `var` if the value of the variable will not change.
+Constants are defined using the `let` keyword and variables with the `var` keyword. Always use `let` instead of `var` if the value of the variable will not change.
 
 **Tip:** A good technique is to define everything using `let` and only change it to `var` if the compiler complains!
 
 You can define constants on a type rather than on an instance of that type using type properties. To declare a type property as a constant simply use `static let`. Type properties declared in this way are generally preferred over global constants because they are easier to distinguish from instance properties. Example:
 
-**Preferred:**
+**Preferred**:
 ```swift
 enum Math {
   static let e = 2.718281828459045235360287
@@ -525,7 +611,7 @@ let hypotenuse = side * Math.root2
 ```
 **Note:** The advantage of using a case-less enumeration is that it can't accidentally be instantiated and works as a pure namespace.
 
-**Not Preferred:**
+**Not Preferred**:
 ```swift
 let e = 2.718281828459045235360287  // pollutes global namespace
 let root2 = 1.41421356237309504880168872
@@ -539,20 +625,20 @@ Static methods and type properties work similarly to global functions and global
 
 ### Optionals
 
-Declare variables and function return types as optional with `?` where a nil value is acceptable.
+Declare variables and function return types as optional with `?` where a `nil` value is acceptable.
 
-Use implicitly unwrapped types declared with `!` only for instance variables that you know will be initialized later before use, such as subviews that will be set up in `viewDidLoad`.
+Use implicitly unwrapped types declared with `!` only for instance variables that you know will be initialized later before use, such as subviews that will be set up in `viewDidLoad()`. Prefer optional binding to implicitly unwrapped optionals in most other cases.
 
 When accessing an optional value, use optional chaining if the value is only accessed once or if there are many optionals in the chain:
 
 ```swift
-self.textContainer?.textLabel?.setNeedsDisplay()
+textContainer?.textLabel?.setNeedsDisplay()
 ```
 
 Use optional binding when it's more convenient to unwrap once and perform multiple operations:
 
 ```swift
-if let textContainer = self.textContainer {
+if let textContainer = textContainer {
   // do many things with textContainer
 }
 ```
@@ -560,9 +646,9 @@ If the optional value is required to the context, use `guard let ...` with `asse
 
 When naming optional variables and properties, avoid naming them like `optionalString` or `maybeView` since their optional-ness is already in the type declaration.
 
-For optional binding, shadow the original name when appropriate rather than using names like `unwrappedView` or `actualLabel`.
+For optional binding, shadow the original name whenever possible rather than using names like `unwrappedView` or `actualLabel`.
 
-**Preferred:**
+**Preferred**:
 ```swift
 var subview: UIView?
 var volume: Double?
@@ -571,9 +657,15 @@ var volume: Double?
 if let subview = subview, let volume = volume {
   // do something with unwrapped subview and volume
 }
+
+// another example
+UIView.animate(withDuration: 2.0) { [weak self] in
+  guard let self = self else { return }
+  self.alpha = 1.0
+}
 ```
 
-**Not Preferred:**
+**Not Preferred**:
 ```swift
 var optionalSubview: UIView?
 var volume: Double?
@@ -583,14 +675,20 @@ if let unwrappedSubview = optionalSubview {
     // do something with unwrappedSubview and realVolume
   }
 }
+
+// another example
+UIView.animate(withDuration: 2.0) { [weak self] in
+  guard let strongSelf = self else { return }
+  strongSelf.alpha = 1.0
+}
 ```
 
 ### Lazy Initialization
 
-Consider using lazy initialization for finer grain control over object lifetime. This is especially true for `UIViewController` that loads views lazily. You can either use a closure that is immediately called `{ }()` or call a private factory method. Example:
+Consider using lazy initialization for finer grained control over object lifetime. This is especially true for `UIViewController` that loads views lazily. You can either use a closure that is immediately called `{ }()` or call a private factory method. Example:
 
 ```swift
-lazy var locationManager: CLLocationManager = self.makeLocationManager()
+lazy var locationManager = makeLocationManager()
 
 private func makeLocationManager() -> CLLocationManager {
   let manager = CLLocationManager()
@@ -608,9 +706,9 @@ private func makeLocationManager() -> CLLocationManager {
 
 ### Type Inference
 
-Prefer compact code and let the compiler infer the type for constants or variables of single instances. Type inference is also appropriate for small (non-empty) arrays and dictionaries. When required, specify the specific type such as `CGFloat` or `Int16`.
+Prefer compact code and let the compiler infer the type for constants or variables of single instances. Type inference is also appropriate for small, non-empty arrays and dictionaries. When required, specify the specific type such as `CGFloat` or `Int16`.
 
-**Preferred:**
+**Preferred**:
 ```swift
 let message = "Click the button"
 let currentBounds = computeViewBounds()
@@ -618,24 +716,24 @@ var names = ["Mic", "Sam", "Christine"]
 let maximumWidth: CGFloat = 106.5
 ```
 
-**Not Preferred:**
+**Not Preferred**:
 ```swift
 let message: String = "Click the button"
 let currentBounds: CGRect = computeViewBounds()
-let names = [String]()
+var names = [String]()
 ```
 
 #### Type Annotation for Empty Arrays and Dictionaries
 
 For empty arrays and dictionaries, use type annotation. (For an array or dictionary assigned to a large, multi-line literal, use type annotation.)
 
-**Preferred:**
+**Preferred**:
 ```swift
 var names: [String] = []
 var lookup: [String: Int] = [:]
 ```
 
-**Not Preferred:**
+**Not Preferred**:
 ```swift
 var names = [String]()
 var lookup = [String: Int]()
@@ -648,14 +746,14 @@ var lookup = [String: Int]()
 
 Prefer the shortcut versions of type declarations over the full generics syntax.
 
-**Preferred:**
+**Preferred**:
 ```swift
 var deviceModels: [String]
 var employees: [Int: String]
 var faxNumber: Int?
 ```
 
-**Not Preferred:**
+**Not Preferred**:
 ```swift
 var deviceModels: Array<String>
 var employees: Dictionary<Int, String>
@@ -692,14 +790,13 @@ Code should not create reference cycles. Analyze your object graph and prevent s
 
 ### Extending object lifetime
 
-Extend object lifetime using the `[weak self]` and `guard let self = self else { return }` idiom. `[weak self]` is preferred to `[unowned self]` where it is not immediately obvious that `self` outlives the closure. Explicitly extending lifetime is preferred to optional unwrapping.
+Extend object lifetime using the `[weak self]` and `guard let self = self else { return }` idiom. `[weak self]` is preferred to `[unowned self]` where it is not immediately obvious that `self` outlives the closure. Explicitly extending lifetime is preferred to optional chaining.
 
 **Preferred**
 ```swift
 resource.request().onComplete { [weak self] response in
-  guard let self = self else {
-    return
-  }
+
+  guard let self = self else { return }
   let model = self.updateModel(response)
   self.updateUI(model)
 }
@@ -709,6 +806,7 @@ resource.request().onComplete { [weak self] response in
 ```swift
 // might crash if self is released before response returns
 resource.request().onComplete { [unowned self] response in
+
   let model = self.updateModel(response)
   self.updateUI(model)
 }
@@ -718,6 +816,7 @@ resource.request().onComplete { [unowned self] response in
 ```swift
 // deallocate could happen between updating the model and updating UI
 resource.request().onComplete { [weak self] response in
+
   let model = self?.updateModel(response)
   self?.updateUI(model)
 }
@@ -727,8 +826,9 @@ resource.request().onComplete { [weak self] response in
 ```swift
 // This has been confirmed as a compiler hack and should be avoided
 resource.request().onComplete { [weak self] response in
+
   guard let `self` = self else {
-    return
+      return
   }
   let model = strongSelf.updateModel(response)
   strongSelf.updateUI(model)
@@ -739,9 +839,11 @@ resource.request().onComplete { [weak self] response in
 ```swift
 // Lacks consistency and makes the codebase harder to reason about
 resource.request().onComplete { [weak self] response in
+
   guard let strongSelf = self else {
-    return
+      return
   }
+
   let model = strongSelf.updateModel(response)
   strongSelf.updateUI(model)
 }
@@ -756,21 +858,21 @@ Only explicitly use `open`, `public`, and `internal` when you require a full acc
 
 Use access control as the leading property specifier. The only things that should come before access control are the `static` specifier or attributes such as `@IBAction`, `@IBOutlet` and `@discardableResult`.
 
-**Preferred:**
+**Preferred**:
 ```swift
 private let message = "Great Scott!"
 
-class TimeMachine {  
-  fileprivate dynamic lazy var fluxCapacitor = FluxCapacitor()
+class TimeMachine {
+  private dynamic lazy var fluxCapacitor = FluxCapacitor()
 }
 ```
 
-**Not Preferred:**
+**Not Preferred**:
 ```swift
 fileprivate let message = "Great Scott!"
 
-class TimeMachine {  
-  lazy dynamic fileprivate var fluxCapacitor = FluxCapacitor()
+class TimeMachine {
+  lazy dynamic private var fluxCapacitor = FluxCapacitor()
 }
 ```
 
@@ -778,7 +880,7 @@ class TimeMachine {
 
 Prefer the `for-in` style of `for` loop over the `while-condition-increment` style.
 
-**Preferred:**
+**Preferred**:
 ```swift
 for _ in 0..<3 {
   print("Hello three times")
@@ -797,7 +899,7 @@ for index in (0...3).reversed() {
 }
 ```
 
-**Not Preferred:**
+**Not Preferred**:
 ```swift
 var i = 0
 while i < 3 {
@@ -814,11 +916,31 @@ while i < attendeeList.count {
 }
 ```
 
+### Ternary Operator
+
+The Ternary operator, `?:` , should only be used when it increases clarity or code neatness. A single condition is usually all that should be evaluated. Evaluating multiple conditions is usually more understandable as an `if` statement or refactored into instance variables. In general, the best use of the ternary operator is during assignment of a variable and deciding which value to use.
+
+**Preferred**:
+
+```swift
+let value = 5
+result = value != 0 ? x : y
+
+let isHorizontal = true
+result = isHorizontal ? x : y
+```
+
+**Not Preferred**:
+
+```swift
+result = a > b ? x = c > d ? c : d : y
+```
+
 ## Golden Path
 
 When coding with conditionals, the left-hand margin of the code should be the "golden" or "happy" path. That is, don't nest `if` statements. Multiple return statements are OK. The `guard` statement is built for this.
 
-**Preferred:**
+**Preferred**:
 ```swift
 func computeFFT(context: Context?, inputData: InputData?) throws -> Frequencies {
 
@@ -834,7 +956,7 @@ func computeFFT(context: Context?, inputData: InputData?) throws -> Frequencies 
 }
 ```
 
-**Not Preferred:**
+**Not Preferred**:
 ```swift
 func computeFFT(context: Context?, inputData: InputData?) throws -> Frequencies {
 
@@ -852,19 +974,21 @@ func computeFFT(context: Context?, inputData: InputData?) throws -> Frequencies 
 }
 ```
 
-When multiple optionals are unwrapped either with `guard` or `if let`, minimize nesting by using the compound version when possible. Example:
+When multiple optionals are unwrapped either with `guard` or `if let` (same applies to multiple conditions), minimize nesting by using the compound version when possible. In the compound version, place the `guard` on its own line, then ident each condition on its own line. The `else` clause is indented to match the `guard` and the code is indented to match the conditions, as shown below. Example:
 
-**Preferred:**
+**Preferred**:
 ```swift
-guard let number1 = number1,
-      let number2 = number2,
-      let number3 = number3 else {
+guard
+  let number1 = number1,
+  let number2 = number2,
+  let number3 = number3
+else {
   fatalError("impossible")
 }
 // do something with numbers
 ```
 
-**Not Preferred:**
+**Not Preferred**:
 ```swift
 if let number1 = number1 {
   if let number2 = number2 {
@@ -891,12 +1015,12 @@ Swift does not require a semicolon after each statement in your code. They are o
 
 Do not write multiple statements on a single line separated with semicolons.
 
-**Preferred:**
+**Preferred**:
 ```swift
 let swift = "not a scripting language"
 ```
 
-**Not Preferred:**
+**Not Preferred**:
 ```swift
 let swift = "not a scripting language";
 ```
@@ -907,14 +1031,14 @@ let swift = "not a scripting language";
 
 Parentheses around conditionals are not required and should be omitted.
 
-**Preferred:**
+**Preferred**:
 ```swift
 if name == "Hello" {
   print("World")
 }
 ```
 
-**Not Preferred:**
+**Not Preferred**:
 ```swift
 if (name == "Hello") {
   print("World")
@@ -923,9 +1047,46 @@ if (name == "Hello") {
 
 In larger expressions, optional parentheses can sometimes make code read more clearly.
 
-**Preferred:**
+**Preferred**:
 ```swift
 let playerMark = (player == current ? "X" : "O")
+```
+
+## Multi-line String Literals
+
+When building a long string literal, you're encouraged to use the multi-line string literal syntax. Open the literal on the same line as the assignment but do not include text on that line. Indent the text block one additional level.
+
+**Preferred**:
+
+```swift
+let message = """
+  You cannot charge the flux \
+  capacitor with a 9V battery.
+  You must use a super-charger \
+  which costs 10 credits. You currently \
+  have \(credits) credits available.
+  """
+```
+
+**Not Preferred**:
+
+```swift
+let message = """You cannot charge the flux \
+  capacitor with a 9V battery.
+  You must use a super-charger \
+  which costs 10 credits. You currently \
+  have \(credits) credits available.
+  """
+```
+
+**Not Preferred**:
+
+```swift
+let message = "You cannot charge the flux " +
+  "capacitor with a 9V battery.\n" +
+  "You must use a super-charger " +
+  "which costs 10 credits. You currently " +
+  "have \(credits) credits available."
 ```
 
 ## Organization and Bundle Identifier

--- a/README.markdown
+++ b/README.markdown
@@ -534,9 +534,9 @@ private var _state: Int
 let dynamicState: Property<Int>
 private let _dynamicState: MutableProperty<Int>
 
-func reticulateSplines(spline: [String])
+func reticulateSplines(_ splines: [String])
 ...
-private func _reticulateSplines(spline: [String], configuration: Configuration)
+private func _reticulateSplines(_ splines: [String], configuration: Configuration)
 
 func sort(numbers: [Int])
 ...
@@ -551,9 +551,9 @@ private var internalState: Int
 let dynamicState: Property<Int>
 private let mutableDynamicState: MutableProperty<Int>
 
-func reticulateSplines(spline: [String])
+func reticulateSplines(_ splines: [String])
 ...
-private func reticulateSplinesHelper(spline: [String], configuration: Configuration)
+private func reticulateSplinesHelper(splines: [String], configuration: Configuration)
 
 func sort(numbers: [Int])
 ...

--- a/README.markdown
+++ b/README.markdown
@@ -19,12 +19,16 @@
     - [Minimal Imports](#minimal-imports)
   - [Spacing](#spacing)
   - [Comments](#comments)
+    - [Documentation](#documentation)
   - [Classes and Structures](#classes-and-structures)
     - [Which one to use?](#which-one-to-use)
     - [Example definition](#example-definition)
     - [Use of Self](#use-of-self)
     - [Computed Properties](#computed-properties)
+    - [Shadowing private members](#shadowing-private-members)
     - [Final](#final)
+    - [Generics](#generics-1)
+  - [Type aliases](#type-aliases)
   - [Function Declarations](#function-declarations)
   - [Function Calls](#function-calls)
   - [Closure Expressions](#closure-expressions)
@@ -40,8 +44,10 @@
   - [Memory Management](#memory-management)
     - [Extending object lifetime](#extending-object-lifetime)
   - [Access Control](#access-control)
+  - [Attributes](#attributes)
   - [Control Flow](#control-flow)
     - [Ternary Operator](#ternary-operator)
+    - [`switch` statements](#switch-statements)
   - [Golden Path](#golden-path)
     - [Failing Guards](#failing-guards)
   - [Semicolons](#semicolons)
@@ -103,7 +109,7 @@ For the above example using `UIGestureRecognizer`, 1 is unambiguous and preferre
 
 ### Class Prefixes
 
-Swift types are automatically namespaced by the module that contains them and you should not add a class prefix such as RW. If two names from different modules collide you can disambiguate by prefixing the type name with the module name. However, only specify the module name when there is possibility for confusion which should be rare.
+Swift types are automatically namespaced by the module that contains them and you should not add a class prefix such as MND. If two names from different modules collide you can disambiguate by prefixing the type name with the module name. However, only specify the module name when there is possibility for confusion which should be rare.
 
 ```swift
 import SomeModule
@@ -279,17 +285,17 @@ var deviceModels: [String]
 
 ## Spacing
 
-* Indent using 4 spaces rather than tabs to conserve space and help prevent line wrapping. Check xcode settings at the end.
-
+* Indent using **4 spaces** rather than tabs to conserve space and help prevent line wrapping. Check xcode settings at the end.
 * Method braces and other braces (`if`/`else`/`switch`/`while` etc.) always open on the same line as the statement but close on a new line.
-* Tip: You can re-indent by selecting some code (or **Command-A** to select all) and then **Control-I** (or **Editor ▸ Structure ▸ Re-Indent** in the menu). Some of the Xcode template code will have 4-space tabs hard coded, so this is a good way to fix that.
+
+**Tip**: You can re-indent by selecting some code (or **Command-A** to select all) and then **Control-I** (or **Editor ▸ Structure ▸ Re-Indent** in the menu). Some of the Xcode template code will have 4-space tabs hard coded, so this is a good way to fix that.
 
 **Preferred**:
 ```swift
 if user.isHappy {
-  // Do something
+    // Do something
 } else {
-  // Do something else
+    // Do something else
 }
 ```
 
@@ -297,10 +303,10 @@ if user.isHappy {
 ```swift
 if user.isHappy
 {
-  // Do something
+    // Do something
 }
 else {
-  // Do something else
+    // Do something else
 }
 ```
 
@@ -314,18 +320,18 @@ else {
 ```swift
 class TestDatabase: Database {
 
-  var data: [String: CGFloat] = ["A": 1.2, "B": 3.2]
+    var data: [String: CGFloat] = ["A": 1.2, "B": 3.2]
 }
 ```
 
 **Not Preferred**:
 ```swift
 class TestDatabase : Database {
-  var data :[String:CGFloat] = ["A" : 1.2, "B":3.2, "C" :2.2]
+    var data :[String:CGFloat] = ["A" : 1.2, "B":3.2, "C" :2.2]
 }
 ```
 
-* Long lines should be wrapped at 120 characters.
+* Long lines should be wrapped at **120 characters**.
 
 * Remove any trailing whitespaces at the ends of lines.
 
@@ -340,6 +346,56 @@ When they are needed, use comments to explain **why** a particular piece of code
 Avoid block comments inline with code, as the code should be as self-documenting as possible. _Exception: This does not apply to those comments used to generate documentation._
 
 Avoid the use of C-style comments (`/* ... */`). Prefer the use of double- or triple-slash.
+
+### Documentation
+
+When documenting code, prefer the triple slash documentation style `///`. 
+
+Prefer one single `- Parameters:` section with bullet points for each parameter to multiple `parameter name:` sections.
+
+Add an empty line between the description and parameters.
+
+Try to take advantage of existing keywords (e.g. `Returns`, `Throws`, `Warning`, `Attention` ...), code ( single line `` `<code>` ``  or `` ```<multiline code>``` `` and overall markdown formatting to provide as much information and details as possible.
+
+**Preferred**:
+```swift
+/// Reticulates some splines using a given adjustment factor `ƒ` and translation constant `∂`.
+///
+/// - Parameters:
+///   - spline: The spline to perform reticulation on.
+///   - adjustmentFactor: The reticulation factor `ƒ`.
+///   - translateConstant: The translation constant `∂`.
+///   - comment: The reticulation operation comment, for logging purposes.
+/// - Returns: A flag indicating if reticulation was successful.
+func reticulateSplines(
+    spline: [Double],
+    adjustmentFactor: Double,
+    translateConstant: Int, 
+    comment: String
+) -> Bool {
+    ...
+}
+```
+
+**Not Preferred**:
+```swift
+/**
+ Reticulates some splines using a given adjustment factor `ƒ` and translation constant `∂`.
+ - parameter spline: The spline to perform reticulation on.
+ - parameter adjustmentFactor: The reticulation factor `ƒ`.
+ - parameter translateConstant: The translation constant `∂`.
+ - parameter comment: The reticulation operation comment, for logging purposes.
+ - returns: A flag indicating if reticulation was successful.
+*/
+func reticulateSplines(
+    spline: [Double],
+    adjustmentFactor: Double,
+    translateConstant: Int, 
+    comment: String
+) -> Bool {
+    ...
+}
+```
 
 ## Classes and Structures
 
@@ -357,39 +413,37 @@ Here's an example of a well-styled class definition:
 
 ```swift
 class Circle: Shape {
-  var x: Int, y: Int
-  var radius: Double
-  var diameter: Double {
-    get {
-      return radius * 2
+
+    var x: Int, y: Int
+    var radius: Double
+    var diameter: Double {
+        get { radius * 2 }
+        set { radius = newValue / 2 }
     }
-    set {
-      radius = newValue / 2
+
+    init(x: Int, y: Int, radius: Double) {
+
+        self.x = x
+        self.y = y
+        self.radius = radius
     }
-  }
 
-  init(x: Int, y: Int, radius: Double) {
-    self.x = x
-    self.y = y
-    self.radius = radius
-  }
+    convenience init(x: Int, y: Int, diameter: Double) {
 
-  convenience init(x: Int, y: Int, diameter: Double) {
-    self.init(x: x, y: y, radius: diameter / 2)
-  }
+        self.init(x: x, y: y, radius: diameter / 2)
+    }
 
-  override func area() -> Double {
-    return Double.pi * radius * radius
-  }
+    override func area() -> Double {
+
+        return Double.pi * radius * radius
+    }
 }
 
 extension Circle: CustomStringConvertible {
-  var description: String {
-    return "center = \(centerString) area = \(area())"
-  }
-  private var centerString: String {
-    return "(\(x),\(y))"
-  }
+
+    var description: String { "center = \(centerString) area = \(area())" }
+
+    private var centerString: String { "(\(x),\(y))" }
 }
 ```
 
@@ -401,32 +455,74 @@ The example above demonstrates the following style guidelines:
  + Don't add modifiers such as `internal` when they're already the default. Similarly, don't repeat the access modifier when overriding a method.
  + Organize extra functionality (e.g. printing) in extensions.
  + Hide non-shared, implementation details such as `centerString` inside the extension using `private` access control.
+ + Take advantage of Swift 5.1's implicit `return` in one line closures.
 
 ### Use of Self
 
 For conciseness, avoid using `self` since Swift does not require it to access an object's properties or invoke its methods.
 
-Use self only when required by the compiler (in `@escaping` closures, or in initializers to disambiguate properties from arguments). In other words, if it compiles without `self` then omit it.
-
+Use `self` only when required by the compiler (e.g. in `@escaping` closures) or inside `init`'s when initializing each property (i.e. not just to disambiguate properties from arguments, but on **all** of them).
 
 ### Computed Properties
 
 For conciseness, if a computed property is read-only, omit the get clause. The get clause is required only when a set clause is provided.
 
+If possible, take advantage of Swift 5.1's implicit `return` in one line closures, and put the closure body inline with the property declaration.
+
 **Preferred**:
 ```swift
-var diameter: Double {
-  return radius * 2
-}
+var diameter: Double { radius * 2 }
 ```
 
 **Not Preferred**:
 ```swift
 var diameter: Double {
-  get {
-    return radius * 2
-  }
+    get {
+      return radius * 2
+    }
 }
+```
+
+### Shadowing private members
+
+Sometimes we need to expose some members like properties and functions publicly (e.g. for read-only property), but have a **shadowing** version for private usage (e.g. read-write property). 
+
+* When shadowing a property, the private property's name **should** be prefixed with a `_`, instead of more verbose alternatives like  `mutatingX`, etc..
+
+* When shadowing a function, the private function's name **can** be prefixed with a `_`, in the lack of a more well suited name to define it.
+
+**Preferred**:
+```swift
+var state: Int { _state }
+private var _state: Int
+
+let dynamicState: Property<Int>
+private let _dynamicState: MutableProperty<Int>
+
+func reticulateSplines(spline: [String])
+...
+private func _reticulateSplines(spline: [String], configuration: Configuration)
+
+func sort(numbers: [Int])
+...
+private func mergeSort(numbers: [String], parameters: Parameters)
+```
+
+**Not Preferred**:
+```swift
+var state: Int { internalState }
+private var internalState: Int
+
+let dynamicState: Property<Int>
+private let mutableDynamicState: MutableProperty<Int>
+
+func reticulateSplines(spline: [String])
+...
+private func reticulateSplinesHelper(spline: [String], configuration: Configuration)
+
+func sort(numbers: [Int])
+...
+private func calculateSort(numbers: [String], parameters: Parameters)
 ```
 
 ### Final
@@ -442,11 +538,85 @@ In the below example, `Box` has a particular purpose and customization in a deri
 ```swift
 // Turn any generic type into a reference type using this Box class.
 final class Box<T> {
-  let value: T
-  init(_ value: T) {
-    self.value = value
-  }
+
+    let value: T
+
+    init(_ value: T) {
+
+        self.value = value
+    }
 }
+```
+
+### Generics
+
+When defining a generic type, prefer inlining the generic declaration and constraints whenever possible. If not possible, break it according to the following rules: 
+
+* move the `where` clause to a separate line, if it doesn't fit inline.
+  * break the conditions in the `where` clause to separate lines if they don't fit into a single line.
+* break the generic declaration `<>`  into separate lines, by adding a line break after the initial `<`, then putting each type in its own line with an extra indentation, and "closing" the generic with a `>:` in its own line, aligned with the initial declaration.
+* When the generic declaration is broken into multiple lines, each conformance/subclassing should be put on a separate line as well.
+
+```swift
+final class MyAwesomeType<
+    SomeGeneric,
+    AnotherGeneric,
+    YetAnotherGeneric
+>:
+    MyProtocol, SomeOtherProtocol, YetAnotherProtocol,
+    NamingIsHardSoSometimesWeNeedVeryLargeNamesInAProtocol
+where
+    SomeGeneric: Some & Nice & Composable & Protocols,
+    AnotherGeneric.SubType == SomeOtherType,
+    YetAnotherGeneric.YetAnotherSubType == YetAnotherType
+{
+    
+    let myProperty: Bool
+
+    func init() {}
+}
+```
+
+## Type aliases
+
+When defining a typealias, prefer inlining its declaration and constraints whenever possible. If not possible, break it according to the following rules:
+
+* move the `where` clause to a separate line if it doesn't fit inline, indenting it an additional level.
+  * break the conditions in the `where` clause to separate lines if they don't fit into a single line.
+* move the type being aliased to the next line if it doesn't fit inline, indenting it an additional level.
+* break the generic declaration `<>` of the type beind aliased into separate lines, by adding a line break after the initial `<`, then putting each type in its own line with an extra indentation, and "closing" the generic with a `>` in its own line, aligned with the aliased type's declaration.
+
+```swift
+typealias SomeSimpleTypealias = SomeType<SomeGeneric>
+
+typealias SomeGenericTypealias<SomeGeneric> = SomeOtherType<SomeGeneric> where SomeGeneric: SomeProtocol
+
+typealias SomeOtherGenericTypealias<SomeGeneric> = YetAnotherType<SomeGeneric>
+    where SomeGeneric: SomeProtocol & And & A & Bunch & Of & Others
+
+typealias SomeOtherGenericTypealias<SomeGeneric> = YetAnotherType<SomeGeneric>
+    where 
+        SomeGeneric: SomeProtocol & And & A & Bunch & Of & Others,
+        SomeGeneric.InternalType == SomeOtherType
+
+typealias MyVeryLargeTypeAlias =
+    MyVeryLongNamedGenericType<
+        SomeGeneric<
+            WhySoManyGenericTypes,
+            IAmSureThereMustBeAnEasierWay,
+            IGuessSometimesWeJustHaveLotsOfComplexAbstractions,
+        >,
+        SomeOtherGeneric
+    >
+
+typealias MyLargeTypeAlias =    
+    SomeOtherVeyLongNamedGenericType<ThatHasItsOwnGenericType<WhichItselfHasAnotherGenericType>>
+
+typealias YetAnotherGenericTypealias<AnotherGeneric> = 
+    YetAnotherVeryLongNamedGenericType<AnotherGeneric>
+    where 
+        AnotherGeneric: AnotherProtocol & And & His & Friends
+        AnotherGeneric.SuperImportantType == YetAnotherType
 ```
 
 ## Function Declarations
@@ -455,7 +625,7 @@ Keep short function declarations on one line including the opening brace:
 
 ```swift
 func reticulateSplines(spline: [Double]) -> Bool {
-  // reticulate code goes here
+    // reticulate code goes here
 }
 ```
 
@@ -463,24 +633,25 @@ For functions with long signatures, put each parameter on a new line and add an 
 
 ```swift
 func reticulateSplines(
-  spline: [Double],
-  adjustmentFactor: Double,
-  translateConstant: Int, comment: String
+    spline: [Double],
+    adjustmentFactor: Double,
+    translateConstant: Int, 
+    comment: String
 ) -> Bool {
 
-  // reticulate code goes here
+    // reticulate code goes here
 }
 ```
 
 **Note:** We can use Xcode automatic alignment by pressing return before each parameter.
-Don't use `(Void)` to represent the lack of an input; simply use `()`. Use `Void` instead of `()` for closure and function outputs.
+Don't use `(Void)` to represent the lack of an input; simply use `()`. Use `Void` instead of `()` for closure and function outputs, and omit `Void` return type on function declarations.
 
 **Preferred**:
 
 ```swift
-func updateConstraints() -> Void {
+func updateConstraints() {
 
-  // magic happens here
+    // magic happens here
 }
 
 typealias CompletionHandler = (result) -> Void
@@ -491,7 +662,12 @@ typealias CompletionHandler = (result) -> Void
 ```swift
 func updateConstraints() -> () {
 
-  // magic happens here
+    // magic happens here
+}
+
+func updateConstraints() -> Void {
+
+    // magic happens here
 }
 
 typealias CompletionHandler = (result) -> ()
@@ -526,11 +702,23 @@ UIView.animate(withDuration: 1.0) {
   self.myView.alpha = 0
 }
 
-UIView.animate(withDuration: 1.0, animations: {
-  self.myView.alpha = 0
-}, completion: { finished in
-  self.myView.removeFromSuperview()
-})
+UIView.animate(
+    withDuration: 1.0,
+    animations: { self.myView.alpha = 0 },
+    completion: { finished in self.myView.removeFromSuperview() }
+)
+
+UIView.animate(
+    withDuration: 1.0,
+    animations: {
+        self.myView.alpha = 0
+        ...
+    },
+    completion: { finished in
+        self.myView.removeFromSuperview()
+        ...
+    }
+)
 ```
 
 **Not Preferred**:
@@ -609,7 +797,7 @@ enum Math {
 let hypotenuse = side * Math.root2
 
 ```
-**Note:** The advantage of using a case-less enumeration is that it can't accidentally be instantiated and works as a pure namespace.
+**Note:** The advantage of using a case-less `enum` is that it can't accidentally be instantiated and works as a pure namespace.
 
 **Not Preferred**:
 ```swift
@@ -627,7 +815,7 @@ Static methods and type properties work similarly to global functions and global
 
 Declare variables and function return types as optional with `?` where a `nil` value is acceptable.
 
-Use implicitly unwrapped types declared with `!` only for instance variables that you know will be initialized later before use, such as subviews that will be set up in `viewDidLoad()`. Prefer optional binding to implicitly unwrapped optionals in most other cases.
+Avoid the usage of implicitly unwrapped optionals (declared with `!`), except on unit tests and when dealing with storyboard outlets. Prefer optional binding to implicitly unwrapped optionals in all other cases.
 
 When accessing an optional value, use optional chaining if the value is only accessed once or if there are many optionals in the chain:
 
@@ -639,9 +827,10 @@ Use optional binding when it's more convenient to unwrap once and perform multip
 
 ```swift
 if let textContainer = textContainer {
-  // do many things with textContainer
+    // do many things with textContainer
 }
 ```
+
 If the optional value is required to the context, use `guard let ...` with `assertionFailure` to catch the problem in debug time or `fatalError` if the execution cannot continue.
 
 When naming optional variables and properties, avoid naming them like `optionalString` or `maybeView` since their optional-ness is already in the type declaration.
@@ -655,13 +844,13 @@ var volume: Double?
 
 // later on...
 if let subview = subview, let volume = volume {
-  // do something with unwrapped subview and volume
+    // do something with unwrapped subview and volume
 }
 
 // another example
 UIView.animate(withDuration: 2.0) { [weak self] in
-  guard let self = self else { return }
-  self.alpha = 1.0
+    guard let self = self else { return }
+    self.alpha = 1.0
 }
 ```
 
@@ -671,15 +860,15 @@ var optionalSubview: UIView?
 var volume: Double?
 
 if let unwrappedSubview = optionalSubview {
-  if let realVolume = volume {
-    // do something with unwrappedSubview and realVolume
-  }
+    if let realVolume = volume {
+      // do something with unwrappedSubview and realVolume
+    }
 }
 
 // another example
 UIView.animate(withDuration: 2.0) { [weak self] in
-  guard let strongSelf = self else { return }
-  strongSelf.alpha = 1.0
+    guard let strongSelf = self else { return }
+    strongSelf.alpha = 1.0
 }
 ```
 
@@ -691,11 +880,12 @@ Consider using lazy initialization for finer grained control over object lifetim
 lazy var locationManager = makeLocationManager()
 
 private func makeLocationManager() -> CLLocationManager {
-  let manager = CLLocationManager()
-  manager.desiredAccuracy = kCLLocationAccuracyBest
-  manager.delegate = self
-  manager.requestAlwaysAuthorization()
-  return manager
+
+    let manager = CLLocationManager()
+    manager.desiredAccuracy = kCLLocationAccuracyBest
+    manager.delegate = self
+    manager.requestAlwaysAuthorization()
+    return manager
 }
 ```
 
@@ -740,7 +930,6 @@ var lookup = [String: Int]()
 ```
 
 **NOTE**: Following this guideline means picking descriptive names is even more important than before.
-
 
 ### Syntactic Sugar
 
@@ -796,9 +985,9 @@ Extend object lifetime using the `[weak self]` and `guard let self = self else {
 ```swift
 resource.request().onComplete { [weak self] response in
 
-  guard let self = self else { return }
-  let model = self.updateModel(response)
-  self.updateUI(model)
+    guard let self = self else { return }
+    let model = self.updateModel(response)
+    self.updateUI(model)
 }
 ```
 
@@ -807,8 +996,8 @@ resource.request().onComplete { [weak self] response in
 // might crash if self is released before response returns
 resource.request().onComplete { [unowned self] response in
 
-  let model = self.updateModel(response)
-  self.updateUI(model)
+    let model = self.updateModel(response)
+    self.updateUI(model)
 }
 ```
 
@@ -817,8 +1006,8 @@ resource.request().onComplete { [unowned self] response in
 // deallocate could happen between updating the model and updating UI
 resource.request().onComplete { [weak self] response in
 
-  let model = self?.updateModel(response)
-  self?.updateUI(model)
+    let model = self?.updateModel(response)
+    self?.updateUI(model)
 }
 ```
 
@@ -827,11 +1016,11 @@ resource.request().onComplete { [weak self] response in
 // This has been confirmed as a compiler hack and should be avoided
 resource.request().onComplete { [weak self] response in
 
-  guard let `self` = self else {
-      return
-  }
-  let model = strongSelf.updateModel(response)
-  strongSelf.updateUI(model)
+    guard let `self` = self else {
+        return
+    }
+    let model = strongSelf.updateModel(response)
+    strongSelf.updateUI(model)
 }
 ```
 
@@ -840,12 +1029,12 @@ resource.request().onComplete { [weak self] response in
 // Lacks consistency and makes the codebase harder to reason about
 resource.request().onComplete { [weak self] response in
 
-  guard let strongSelf = self else {
-      return
-  }
+    guard let strongSelf = self else {
+        return
+    }
 
-  let model = strongSelf.updateModel(response)
-  strongSelf.updateUI(model)
+    let model = strongSelf.updateModel(response)
+    strongSelf.updateUI(model)
 }
 ```
 
@@ -863,7 +1052,8 @@ Use access control as the leading property specifier. The only things that shoul
 private let message = "Great Scott!"
 
 class TimeMachine {
-  private dynamic lazy var fluxCapacitor = FluxCapacitor()
+
+    private dynamic lazy var fluxCapacitor = FluxCapacitor()
 }
 ```
 
@@ -872,7 +1062,36 @@ class TimeMachine {
 fileprivate let message = "Great Scott!"
 
 class TimeMachine {
-  lazy dynamic private var fluxCapacitor = FluxCapacitor()
+    lazy dynamic private var fluxCapacitor = FluxCapacitor()
+}
+```
+
+## Attributes
+
+* Attributes such as `@IBAction`, `@IBOutlet`, `@discardableResult`, `@objc`, etc should be placed in the line **above** the declaration and stacked vertically, and not inline.
+* The only exception to this is `@unknown default:` in `switch` statements.
+
+**Preferred**:
+```swift
+@objc(MNDTimeMachine)
+class TimeMachine: NSObject {
+
+    @available(*, unavailable)
+    private dynamic lazy var fluxCapacitor = FluxCapacitor()
+
+    @discardableResult
+    @objc
+    func calculateFlux() -> Flux
+}
+```
+
+**Not Preferred**:
+```swift
+@objc(MNDTimeMachine) class TimeMachine: NSObject {
+    
+    @available(*, unavailable) lazy dynamic private var fluxCapacitor = FluxCapacitor()
+
+    @discarcableResult @objc func calculateFlux() -> Flux
 }
 ```
 
@@ -883,19 +1102,19 @@ Prefer the `for-in` style of `for` loop over the `while-condition-increment` sty
 **Preferred**:
 ```swift
 for _ in 0..<3 {
-  print("Hello three times")
+    print("Hello three times")
 }
 
 for (index, person) in attendeeList.enumerated() {
-  print("\(person) is at position #\(index)")
+    print("\(person) is at position #\(index)")
 }
 
 for index in stride(from: 0, to: items.count, by: 2) {
-  print(index)
+    print(index)
 }
 
 for index in (0...3).reversed() {
-  print(index)
+    print(index)
 }
 ```
 
@@ -903,22 +1122,24 @@ for index in (0...3).reversed() {
 ```swift
 var i = 0
 while i < 3 {
-  print("Hello three times")
-  i += 1
+    print("Hello three times")
+    i += 1
 }
 
 
 var i = 0
 while i < attendeeList.count {
-  let person = attendeeList[i]
-  print("\(person) is at position #\(i)")
-  i += 1
+    let person = attendeeList[i]
+    print("\(person) is at position #\(i)")
+    i += 1
 }
 ```
 
 ### Ternary Operator
 
 The Ternary operator, `?:` , should only be used when it increases clarity or code neatness. A single condition is usually all that should be evaluated. Evaluating multiple conditions is usually more understandable as an `if` statement or refactored into instance variables. In general, the best use of the ternary operator is during assignment of a variable and deciding which value to use.
+
+For large expressions, break the ternary operator into multiple lines, with the `?` and `:` expressions each in its own line.
 
 **Preferred**:
 
@@ -928,12 +1149,80 @@ result = value != 0 ? x : y
 
 let isHorizontal = true
 result = isHorizontal ? x : y
+
+let isHorizontal = true
+result = isHorizontal
+    ? mySuperComplexExpression(z)
+    : someOtherComplexExpression(w)
 ```
 
 **Not Preferred**:
 
 ```swift
 result = a > b ? x = c > d ? c : d : y
+```
+
+### `switch` statements
+
+When using `switch`, please try to adopt the following rules:
+
+* Add a newline between each `case` block in `switch` statements if at least one spans more than one line.
+* Always place every `case` body in its own separate line, with an extra indentation.
+* When multiple conditions/patterns are defined in a single `case`, prefer putting each one in its own line to ease redability and make diffs nicer upon changes.
+* Capture associated values in `enum`'s (e.g. `var` or `let`) at a **value level** and not at a *case level*.
+* Try to place the `where` clause inline with the respective `case`, and if not possible move it to the next line, at the same indentation.
+  * If compounding multiple predicates in the `where` clause, use `,` instead of explicit `&&`'s.
+* Prefer explicitly handling all cases instead of using a `default` case.
+
+**Preferred**:
+```swift
+switch value {
+case .first:
+    // some magic
+case .second:
+    // alternative magic
+case .third:
+    // ultimate magic
+}
+
+switch anotherValue {
+case .potato(let kg):
+    print("🥔 weights \(kg)Kg's")
+
+case .banana(let g), 
+    .apple(let g), 
+    .watermelon(let g):
+    print("🍌|🍏|🍉 weights \(g)g's")
+    addFruitToSalad()
+
+case .eggs(let number, let size) 
+where size == .large, someLongFunctionThatTakesUpALotOfSpaceAndValidatesNumber(number):
+    print("🥚 amount of Large eggs that passed the test: \(number)")
+
+case .eggs(let number, let size):
+    print("🥚 amount to \(number) of size \(size)")
+}
+```
+
+**Not Preferred**:
+```swift
+switch value {
+case .first: // some magic
+case .second: // alternative magic
+case .third: // ultimate magic
+}
+
+switch anotherValue {
+case let .potato(kg):
+    print("🥔 weights \(kg)Kg's")
+case .banana(let g),  .apple(let g), .watermelon(let g):
+    print("🍌|🍏|🍉 weights \(g)g's")
+    addFruitToSalad()
+case let .eggs(number, size) where size == .large && someLongFunctionThatTakesUpALotOfSpaceAndValidatesNumber(number):
+    print("🥚 amount to \(number) of size \(size)")
+default:
+    print("🤷‍♂️ Got some food which *should be™* eggs: \(anotherValue)")
+}
 ```
 
 ## Golden Path
@@ -944,15 +1233,12 @@ When coding with conditionals, the left-hand margin of the code should be the "g
 ```swift
 func computeFFT(context: Context?, inputData: InputData?) throws -> Frequencies {
 
-  guard let context = context else {
-    throw FFTError.noContext
-  }
-  guard let inputData = inputData else {
-    throw FFTError.noInputData
-  }
+    guard let context = context else { throw FFTError.noContext }
 
-  // use context and input to compute the frequencies
-  return frequencies
+    guard let inputData = inputData else { throw FFTError.noInputData }
+
+    // use context and input to compute the frequencies
+    return frequencies
 }
 ```
 
@@ -960,17 +1246,17 @@ func computeFFT(context: Context?, inputData: InputData?) throws -> Frequencies 
 ```swift
 func computeFFT(context: Context?, inputData: InputData?) throws -> Frequencies {
 
-  if let context = context {
-    if let inputData = inputData {
-      // use context and input to compute the frequencies
+    if let context = context {
+        if let inputData = inputData {
+            // use context and input to compute the frequencies
 
-      return frequencies
+            return frequencies
+        } else {
+            throw FFTError.noInputData
+        }
     } else {
-      throw FFTError.noInputData
+        throw FFTError.noContext
     }
-  } else {
-    throw FFTError.noContext
-  }
 }
 ```
 
@@ -979,11 +1265,11 @@ When multiple optionals are unwrapped either with `guard` or `if let` (same appl
 **Preferred**:
 ```swift
 guard
-  let number1 = number1,
-  let number2 = number2,
-  let number3 = number3
+    let number1 = number1,
+    let number2 = number2,
+    let number3 = number3
 else {
-  fatalError("impossible")
+    fatalError("impossible")
 }
 // do something with numbers
 ```
@@ -991,23 +1277,63 @@ else {
 **Not Preferred**:
 ```swift
 if let number1 = number1 {
-  if let number2 = number2 {
-    if let number3 = number3 {
-      // do something with numbers
+    if let number2 = number2 {
+        if let number3 = number3 {
+          // do something with numbers
+        } else {
+          fatalError("impossible")
+        }
     } else {
-      fatalError("impossible")
+        fatalError("impossible")
     }
-  } else {
-    fatalError("impossible")
-  }
 } else {
-  fatalError("impossible")
+    fatalError("impossible")
 }
 ```
 
 ### Failing Guards
 
 Guard statements are required to exit in some way. Generally, this should be simple one line statement such as `return`, `throw`, `break`, `continue`, and `fatalError()`. Large code blocks should be avoided. If cleanup code is required for multiple exit points, consider using a `defer` block to avoid cleanup code duplication.
+
+if possible, place the exit closure inline with the `guard`, otherwise in a new line:
+
+**Preferred**:
+```swift
+guard let number = number else { fatalError("impossible") }
+// do something with number
+```
+
+```swift
+guard let number = number else {
+    ...
+    fatalError("impossible")
+}
+// do something with number
+```
+
+**Not Preferred**:
+```swift
+guard let number = number
+else { fatalError("impossible") }
+// do something with number
+```
+
+```swift
+guard let number = number
+else {
+  fatalError("impossible")
+}
+// do something with number
+```
+
+```swift
+guard
+    let number1 = number1,
+    let number2 = number2,
+    let number3 = number3
+else { fatalError("impossible") }
+// do something with numbers
+```
 
 ## Semicolons
 

--- a/README.markdown
+++ b/README.markdown
@@ -52,7 +52,9 @@
     - [Failing Guards](#failing-guards)
   - [Semicolons](#semicolons)
   - [Parentheses](#parentheses)
-  - [Multi-line String Literals](#multi-line-string-literals)
+  - [String Literals](#string-literals)
+    - [Multi-line strings](#multi-line-strings)
+    - [Raw strings](#raw-strings)
   - [Organization and Bundle Identifier](#organization-and-bundle-identifier)
   - [References](#references)
 
@@ -105,7 +107,6 @@ For the above example using `UIGestureRecognizer`, 1 is unambiguous and preferre
 **Pro Tip:** You can use Xcode's jump bar to lookup methods with argument labels. If you’re particularly good at mashing lots of keys simultaneously, put the cursor in the method name and press **Shift-Control-Option-Command-C** (all 4 modifier keys) and Xcode will kindly put the signature on your clipboard.
 
 ![Methods in Xcode jump bar](screens/xcode-jump-bar.png)
-
 
 ### Class Prefixes
 
@@ -196,24 +197,24 @@ In particular, when adding protocol conformance to a model, prefer adding a sepa
 **Preferred**:
 ```swift
 class MyViewController: UIViewController {
-  // class stuff here
+    // class stuff here
 }
 
 // MARK: - UITableViewDataSource
 extension MyViewController: UITableViewDataSource {
-  // table view data source methods
+    // table view data source methods
 }
 
 // MARK: - UIScrollViewDelegate
 extension MyViewController: UIScrollViewDelegate {
-  // scroll view delegate methods
+    // scroll view delegate methods
 }
 ```
 
 **Not Preferred**:
 ```swift
 class MyViewController: UIViewController, UITableViewDataSource, UIScrollViewDelegate {
-  // all methods
+    // all methods
 }
 ```
 
@@ -230,25 +231,29 @@ Methods that simply call the superclass should also be removed. This includes an
 **Preferred**:
 ```swift
 override func tableView(_ tableView: UITableView, numberOfRowsInSection section: Int) -> Int {
-  return Database.contacts.count
+
+    return Database.contacts.count
 }
 ```
 
 **Not Preferred**:
 ```swift
 override func didReceiveMemoryWarning() {
-  super.didReceiveMemoryWarning()
-  // Dispose of any resources that can be recreated.
+    super.didReceiveMemoryWarning()
+
+    // Dispose of any resources that can be recreated.
 }
 
 override func numberOfSections(in tableView: UITableView) -> Int {
-  // #warning Incomplete implementation, return the number of sections
-  return 1
+
+    // #warning Incomplete implementation, return the number of sections
+    return 1
 }
 
 override func tableView(_ tableView: UITableView, numberOfRowsInSection section: Int) -> Int {
-  // #warning Incomplete implementation, return the number of rows
-  return Database.contacts.count
+
+    // #warning Incomplete implementation, return the number of rows
+    return Database.contacts.count
 }
 
 ```
@@ -288,7 +293,7 @@ var deviceModels: [String]
 * Indent using **4 spaces** rather than tabs to conserve space and help prevent line wrapping. Check xcode settings at the end.
 * Method braces and other braces (`if`/`else`/`switch`/`while` etc.) always open on the same line as the statement but close on a new line.
 
-**Tip**: You can re-indent by selecting some code (or **Command-A** to select all) and then **Control-I** (or **Editor ▸ Structure ▸ Re-Indent** in the menu). Some of the Xcode template code will have 4-space tabs hard coded, so this is a good way to fix that.
+**Pro Tip**: You can re-indent by selecting some code (or **Command-A** to select all) and then **Control-I** (or **Editor ▸ Structure ▸ Re-Indent** in the menu). Some of the Xcode template code will have 4-space tabs hard coded, so this is a good way to fix that.
 
 **Preferred**:
 ```swift
@@ -331,6 +336,39 @@ class TestDatabase : Database {
 }
 ```
 
+* There should be exactly one blank line after each function's declaration before any code. Exceptions are one-line functions that can be inlined, and invoking the `super` of the current method.
+
+**Preferred**:
+
+```swift
+func reticulateSplines(_ splines: [Double]) -> Bool {
+
+    // reticulate code goes here
+}
+
+func reticulateSplines(_ splines: [Double]) -> Bool { /* one-line reticulate code goes here */ }
+
+func reticulateSplines(_ splines: [Double]) -> Bool {
+    super.reticulateSplines(splines)
+
+    // reticulate code goes here
+}
+```
+
+**Not Preferred**:
+
+```swift
+func reticulateSplines(_ splines: [Double]) -> Bool {
+    // reticulate code goes here
+}
+
+func reticulateSplines(_ splines: [Double]) -> Bool {
+
+    super.reticulateSplines(splines)
+    // reticulate code goes here
+}
+```
+
 * Long lines should be wrapped at **120 characters**.
 
 * Remove any trailing whitespaces at the ends of lines.
@@ -349,7 +387,7 @@ Avoid the use of C-style comments (`/* ... */`). Prefer the use of double- or tr
 
 ### Documentation
 
-When documenting code, prefer the triple slash documentation style `///`. 
+When documenting code, prefer the triple slash documentation style `///`.
 
 Prefer one single `- Parameters:` section with bullet points for each parameter to multiple `parameter name:` sections.
 
@@ -368,9 +406,9 @@ Try to take advantage of existing keywords (e.g. `Returns`, `Throws`, `Warning`,
 ///   - comment: The reticulation operation comment, for logging purposes.
 /// - Returns: A flag indicating if reticulation was successful.
 func reticulateSplines(
-    spline: [Double],
+    _ splines: [Double],
     adjustmentFactor: Double,
-    translateConstant: Int, 
+    translateConstant: Int,
     comment: String
 ) -> Bool {
     ...
@@ -388,9 +426,9 @@ func reticulateSplines(
  - returns: A flag indicating if reticulation was successful.
 */
 func reticulateSplines(
-    spline: [Double],
+    _ splines: [Double],
     adjustmentFactor: Double,
-    translateConstant: Int, 
+    translateConstant: Int,
     comment: String
 ) -> Bool {
     ...
@@ -433,10 +471,7 @@ class Circle: Shape {
         self.init(x: x, y: y, radius: diameter / 2)
     }
 
-    override func area() -> Double {
-
-        return Double.pi * radius * radius
-    }
+    override func area() -> Double { Double.pi * radius * radius }
 }
 
 extension Circle: CustomStringConvertible {
@@ -478,14 +513,14 @@ var diameter: Double { radius * 2 }
 ```swift
 var diameter: Double {
     get {
-      return radius * 2
+        return radius * 2
     }
 }
 ```
 
 ### Shadowing private members
 
-Sometimes we need to expose some members like properties and functions publicly (e.g. for read-only property), but have a **shadowing** version for private usage (e.g. read-write property). 
+Sometimes we need to expose some members like properties and functions publicly (e.g. for read-only property), but have a **shadowing** version for private usage (e.g. read-write property).
 
 * When shadowing a property, the private property's name **should** be prefixed with a `_`, instead of more verbose alternatives like  `mutatingX`, etc..
 
@@ -550,7 +585,7 @@ final class Box<T> {
 
 ### Generics
 
-When defining a generic type, prefer inlining the generic declaration and constraints whenever possible. If not possible, break it according to the following rules: 
+When defining a generic type, prefer inlining the generic declaration and constraints whenever possible. If not possible, break it according to the following rules:
 
 * move the `where` clause to a separate line, if it doesn't fit inline.
   * break the conditions in the `where` clause to separate lines if they don't fit into a single line.
@@ -570,7 +605,7 @@ where
     AnotherGeneric.SubType == SomeOtherType,
     YetAnotherGeneric.YetAnotherSubType == YetAnotherType
 {
-    
+
     let myProperty: Bool
 
     func init() {}
@@ -595,7 +630,7 @@ typealias SomeOtherGenericTypealias<SomeGeneric> = YetAnotherType<SomeGeneric>
     where SomeGeneric: SomeProtocol & And & A & Bunch & Of & Others
 
 typealias SomeOtherGenericTypealias<SomeGeneric> = YetAnotherType<SomeGeneric>
-    where 
+    where
         SomeGeneric: SomeProtocol & And & A & Bunch & Of & Others,
         SomeGeneric.InternalType == SomeOtherType
 
@@ -609,22 +644,25 @@ typealias MyVeryLargeTypeAlias =
         SomeOtherGeneric
     >
 
-typealias MyLargeTypeAlias =    
+typealias MyLargeTypeAlias =
     SomeOtherVeyLongNamedGenericType<ThatHasItsOwnGenericType<WhichItselfHasAnotherGenericType>>
 
-typealias YetAnotherGenericTypealias<AnotherGeneric> = 
+typealias YetAnotherGenericTypealias<AnotherGeneric> =
     YetAnotherVeryLongNamedGenericType<AnotherGeneric>
-    where 
+    where
         AnotherGeneric: AnotherProtocol & And & His & Friends
         AnotherGeneric.SuperImportantType == YetAnotherType
 ```
 
 ## Function Declarations
 
+When declaring a function al
+
 Keep short function declarations on one line including the opening brace:
 
 ```swift
-func reticulateSplines(spline: [Double]) -> Bool {
+func reticulateSplines(_ splines: [Double]) -> Bool {
+
     // reticulate code goes here
 }
 ```
@@ -633,9 +671,9 @@ For functions with long signatures, put each parameter on a new line and add an 
 
 ```swift
 func reticulateSplines(
-    spline: [Double],
+    _ splines: [Double],
     adjustmentFactor: Double,
-    translateConstant: Int, 
+    translateConstant: Int,
     comment: String
 ) -> Bool {
 
@@ -685,10 +723,10 @@ If the call site must be wrapped, put each parameter on a new line, indented one
 
 ```swift
 let success = reticulateSplines(
-  spline: splines,
-  adjustmentFactor: 1.3,
-  translateConstant: 2,
-  comment: "normalize the display"
+    _ splines: splines,
+    adjustmentFactor: 1.3,
+    translateConstant: 2,
+    comment: "normalize the display"
 )
 ```
 
@@ -698,9 +736,7 @@ Use trailing closure syntax only if there's a single closure expression paramete
 
 **Preferred**:
 ```swift
-UIView.animate(withDuration: 1.0) {
-  self.myView.alpha = 0
-}
+UIView.animate(withDuration: 1.0) { self.myView.alpha = 0 }
 
 UIView.animate(
     withDuration: 1.0,
@@ -724,13 +760,13 @@ UIView.animate(
 **Not Preferred**:
 ```swift
 UIView.animate(withDuration: 1.0, animations: {
-  self.myView.alpha = 0
+    self.myView.alpha = 0
 })
 
 UIView.animate(withDuration: 1.0, animations: {
-  self.myView.alpha = 0
+    self.myView.alpha = 0
 }) { f in
-  self.myView.removeFromSuperview()
+    self.myView.removeFromSuperview()
 }
 ```
 
@@ -740,7 +776,7 @@ For single-expression closures where the context is clear, use implicit returns:
 attendeeList.sort { $0 > $1 }
 
 attendeeList.sort { first, second in
-  first > second
+    first > second
 }
 ```
 
@@ -750,9 +786,9 @@ Chained methods using trailing closures should be clear and easy to read in cont
 let value = numbers.map { $0 * 2 }.filter { $0 % 3 == 0 }.index(of: 90)
 
 let value = numbers
-  .map {$0 * 2}
-  .filter {$0 > 50}
-  .map {$0 + 10}
+    .map {$0 * 2}
+    .filter {$0 > 50}
+    .map {$0 + 10}
 ```
 
 ## Types
@@ -783,21 +819,21 @@ In drawing code, use `CGFloat` if it makes the code more succinct by avoiding to
 
 Constants are defined using the `let` keyword and variables with the `var` keyword. Always use `let` instead of `var` if the value of the variable will not change.
 
-**Tip:** A good technique is to define everything using `let` and only change it to `var` if the compiler complains!
+**Pro Tip:** A good technique is to define everything using `let` and only change it to `var` if the compiler complains!
 
 You can define constants on a type rather than on an instance of that type using type properties. To declare a type property as a constant simply use `static let`. Type properties declared in this way are generally preferred over global constants because they are easier to distinguish from instance properties. Example:
 
 **Preferred**:
 ```swift
 enum Math {
-  static let e = 2.718281828459045235360287
-  static let root2 = 1.41421356237309504880168872
+    static let e = 2.718281828459045235360287
+    static let root2 = 1.41421356237309504880168872
 }
 
 let hypotenuse = side * Math.root2
 
 ```
-**Note:** The advantage of using a case-less `enum` is that it can't accidentally be instantiated and works as a pure namespace.
+**Pro Tip:** The advantage of using a case-less `enum` is that it can't accidentally be instantiated and works as a pure namespace.
 
 **Not Preferred**:
 ```swift
@@ -892,7 +928,6 @@ private func makeLocationManager() -> CLLocationManager {
 **Notes:**
   - `[unowned self]` is not required here. A retain cycle is not created.
   - Location manager has a side-effect for popping up UI to ask the user for permission so fine grain control makes sense here.
-
 
 ### Type Inference
 
@@ -1019,8 +1054,8 @@ resource.request().onComplete { [weak self] response in
     guard let `self` = self else {
         return
     }
-    let model = strongSelf.updateModel(response)
-    strongSelf.updateUI(model)
+    let model = self.updateModel(response)
+    self.updateUI(model)
 }
 ```
 
@@ -1088,7 +1123,7 @@ class TimeMachine: NSObject {
 **Not Preferred**:
 ```swift
 @objc(MNDTimeMachine) class TimeMachine: NSObject {
-    
+
     @available(*, unavailable) lazy dynamic private var fluxCapacitor = FluxCapacitor()
 
     @discarcableResult @objc func calculateFlux() -> Flux
@@ -1189,13 +1224,13 @@ switch anotherValue {
 case .potato(let kg):
     print("🥔 weights \(kg)Kg's")
 
-case .banana(let g), 
-    .apple(let g), 
+case .banana(let g),
+    .apple(let g),
     .watermelon(let g):
     print("🍌|🍏|🍉 weights \(g)g's")
     addFruitToSalad()
 
-case .eggs(let number, let size) 
+case .eggs(let number, let size)
 where size == .large, someLongFunctionThatTakesUpALotOfSpaceAndValidatesNumber(number):
     print("🥚 amount of Large eggs that passed the test: \(number)")
 
@@ -1295,7 +1330,7 @@ if let number1 = number1 {
 
 Guard statements are required to exit in some way. Generally, this should be simple one line statement such as `return`, `throw`, `break`, `continue`, and `fatalError()`. Large code blocks should be avoided. If cleanup code is required for multiple exit points, consider using a `defer` block to avoid cleanup code duplication.
 
-if possible, place the exit closure inline with the `guard`, otherwise in a new line:
+If possible, place the exit closure inline with the `guard`, otherwise in a new line:
 
 **Preferred**:
 ```swift
@@ -1378,7 +1413,9 @@ In larger expressions, optional parentheses can sometimes make code read more cl
 let playerMark = (player == current ? "X" : "O")
 ```
 
-## Multi-line String Literals
+## String Literals
+
+### Multi-line strings
 
 When building a long string literal, you're encouraged to use the multi-line string literal syntax. Open the literal on the same line as the assignment but do not include text on that line. Indent the text block one additional level.
 
@@ -1413,6 +1450,26 @@ let message = "You cannot charge the flux " +
   "You must use a super-charger " +
   "which costs 10 credits. You currently " +
   "have \(credits) credits available."
+```
+
+### Raw strings
+
+When declaring a string that would require a significant amount of escaping, such as regular expressions, prefer using **raw strings**.
+
+**Preferred**:
+
+```swift
+let json = #"{"email":"banana@banana.com","salutation":"Sir"}"#
+
+let regex = #"(?!(1st|2nd|3rd|\d{1,2}th)\s).*between \d{1,2}-\d{1,2}(am|pm)"#
+```
+
+**Not Preferred**:
+
+```swift
+let json = "{\"email\":\"banana@banana.com\",\"salutation\":\"Sir\"}"
+
+let regex = "(?!(1st|2nd|3rd|\\d{1,2}th)\\s).*between \\d{1,2}-\\d{1,2}(am|pm)"
 ```
 
 ## Organization and Bundle Identifier


### PR DESCRIPTION
At long last, here's the update to our styleguide! 📝✅🚔

## Changes:

- Add new sections:
  + Documentation
  + Shadowing private members
  + Generics
  + Type aliases
  + Attributes
  + `switch` statements
- Add new guideline to use Swift 5.1 implicit returns on single line
closures.
- Refine existing guidelines:
  + `self` usage
  + `Void` function return
  + ternary operator.
  + `guard` statements.
- Make formatting improvements.
- Update code samples to 4 space indentation. 
- Merge some upstream changes
- Revise License and Credits

Feel free to comment/question anything! Ideally read the whole document for a clearer picture of the whole set of guidelines. 🙏 